### PR TITLE
Update to using ALF 2.0 and module bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 *sublime*
 .idea
 *.iml

--- a/createZip.sh
+++ b/createZip.sh
@@ -1,2 +1,5 @@
+npm install
+npm run build
+npm run dist
 rm -rf integration-aftenposten.zip
-zip --exclude=*.DS_Store -r integration-aftenposten.zip gfx index.html disqus.html js vendor
+zip --exclude=*.DS_Store -r integration-aftenposten.zip dist gfx index.html disqus.html

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 	<meta name="apple-mobile-web-app-status-bar-style" content="black" >
 	<meta name="format-detection" content="telephone=no" >
 	<title>DrMobile integration</title>
-	<link rel="stylesheet" type="text/css" href="vendor/aptoma/alf/alf.css">
+	<link rel="stylesheet" type="text/css" href="dist/alf.css">
 	<style type="text/css">
 		.event-frame {
 			display: none;
@@ -50,15 +50,6 @@
 <iframe width="0" height="0" frameborder="0" class="event-frame"></iframe>
 <iframe width="0" height="0" frameborder="0" class="event-frame"></iframe>
 
-<script type="text/javascript" src="vendor/aptoma/alf/alf.min.js"></script>
-<script type="text/javascript" src="js/widget/disqus.js"></script>
-<script type="text/javascript" src="js/widget/banner.js"></script>
-<script type="text/javascript" src="js/main.js"></script>
-<script type="text/javascript">
-require(['main'], function(app){
-  "use strict";
-  //runs main(app) just by referencing it
-});
-</script>
+<script type="text/javascript" src="dist/app.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,252 +1,253 @@
-define('main', ['alf', 'js/widgets/disqus', 'js/widgets/banner', 'js/widgets/phonebanner'], function (Alf, disqus, banner, phonebanner) {
-	"use strict";
-	var $ = Alf.dom;
+"use strict";
 
-	$('.alf-layer-fullscreen').on('singleTap touchstart tap click touchend', 'a', function (ev) { 
-		ev.stopImmediatePropagation(); 
-	});
+var Alf = require('alf');
+var disqus = require('./widget/disqus');
+var banner = require('./widget/banner');
+var phonebanner = require('./widget/phonebanner');
 
-	var widgets = [];
-    widgets.push(disqus);
-    widgets.push(banner);
-    widgets.push(phonebanner);
+var $ = Alf.dom;
+var _ = Alf._;
 
+$('.alf-layer-fullscreen').on('singleTap touchstart tap click touchend', 'a', function (ev) {
+    ev.stopImmediatePropagation();
+});
 
-	var app = {
-		initialize: function () {
-			this.isEmbeddedInApp = this.getURLParameter('isEmbeddedInApp', '1') != '0';
-			this.page = null;
-			this.event = null;
-			this.bridge = null;
-			this.initBridge();
-			this.initLayers();
-		},
+var widgets = [disqus, banner, phonebanner];
 
-		getURLParameter: function(name, fallbackValue) {
-    		return decodeURI(
-        		(RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,fallbackValue])[1]
-    			);
-		},
+var app = {
+    initialize: function () {
+        this.isEmbeddedInApp = this.getURLParameter('isEmbeddedInApp', '1') != '0';
+        this.page = null;
+        this.event = null;
+        this.bridge = null;
+        this.initBridge();
+        this.initLayers();
+    },
 
-		logToApp: function(data) {
-			this.bridge.trigger('log', {
-				"message": data,
-				"level": 1
-			});
-		},
+    getURLParameter: function (name, fallbackValue) {
+        return decodeURI(
+            (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search) || [, fallbackValue])[1]
+        );
+    },
 
-		logToConsole: function(data) {
-			if (typeof console == "object") {
-				console.log(data);
-			}
-		},
+    logToApp: function (data) {
+        this.bridge.trigger('log', {
+            "message": data,
+            "level": 1
+        });
+    },
 
-		logToAll: function(data) {
-			this.logToConsole(data);
-			this.logToApp(data);
-		},
+    logToConsole: function (data) {
+        if (typeof console == "object") {
+            console.log(data);
+        }
+    },
 
-		/**
-		 * Initialize the bridge used for communication between native and HTML
-		 *
-		 * @return {void}
-		 */
-		initBridge: function () {
-			// This is used to trigger HTML-events by the native layer
-			this.event = _.extend({}, Alf.Events);
+    logToAll: function (data) {
+        this.logToConsole(data);
+        this.logToApp(data);
+    },
 
-			// This is used to send event-data to the native app
-			this.bridge = _.extend({}, Alf.Events, {
-			  initialize: function () {
-					this.frameIndex = 0;
-					this.eventFrames = $('.event-frame');
-					this.bind('all', this.eventTriggered);
-				},
+    /**
+     * Initialize the bridge used for communication between native and HTML
+     *
+     * @return {void}
+     */
+    initBridge: function () {
+        // This is used to trigger HTML-events by the native layer
+        this.event = _.extend({}, Alf.Events);
 
-				/**
-				 * Event triggered
-				 *
-				 * This works like a proxy for all events triggered on this.bridge
-				 * Change the src attribute on any of the iframes so the native wrapper app
-				 * can intercept it and decode the JSON payload in the URL
-				 *
-				 * @return {void}
-				 */
-				eventTriggered: function () {
-                    console.log([].slice.call(arguments));
-					var eventInfo = JSON.stringify([].slice.call(arguments));
+        // This is used to send event-data to the native app
+        this.bridge = _.extend({}, Alf.Events, {
+            initialize: function () {
+                this.frameIndex = 0;
+                this.eventFrames = $('.event-frame');
+                this.bind('all', this.eventTriggered);
+            },
 
-                    this.frameIndex = (this.frameIndex + 1) % this.eventFrames.length;
-					if(app.isEmbeddedInApp)
-					{
-                    	this.eventFrames[this.frameIndex].src = 'event://' + escape(eventInfo);
-					}
-					else
-					{
-						app.logToConsole('Event: ' + eventInfo);
-					}
-				}
-			});
+            /**
+             * Event triggered
+             *
+             * This works like a proxy for all events triggered on this.bridge
+             * Change the src attribute on any of the iframes so the native wrapper app
+             * can intercept it and decode the JSON payload in the URL
+             *
+             * @return {void}
+             */
+            eventTriggered: function () {
+                console.log([].slice.call(arguments));
+                var eventInfo = JSON.stringify([].slice.call(arguments));
 
-			this.bridge.initialize();
-		},
-
-		/**
-		 * Initialize layers
-		 *
-		 * This is to enable fullscreen support
-		 * The article/pages and fullscreen elements are rendered in different "layers"
-		 *
-		 * @return {void}
-		 */
-		initLayers: function () {
-
-			this.layerManager = new Alf.layer.Manager();
-
-			this.pageLayer = new Alf.layer.Page({
-				el: '#alf-layer-content',
-				widgets: widgets,
-				manager: this.layerManager
-			});
-
-			this.fullscreenLayer = new Alf.layer.Fullscreen({
-				el: '#alf-layer-fullscreen',
-				manager: this.layerManager
-			});
-
-			this.pageLayer.render();
-			this.fullscreenLayer.render();
-		},
-
-
-		/**
-		 * Render the page on screen
-		 *
-		 * Takes the compiled content and uses Alf.layout.Page to do rendering
-		 *
-		 * @param {HTMLElement} el the element to put the page inside
-		 * @param {Object} deskedPage
-		 * @param {String} contextHash used for race conditions
-		 * @param {String} assetsBaseUrl
-		 * @param {Function} onDone
-		 * @return {void}
-		 */
-		renderPage: function (pageContentEl, deskedPage, assetsBaseUrl, onDone) {
-
-			if (this.page) {
-				this.page.tearDown();
-				this.page = null;
-			}
-
-			var page;
-			//TODO: remove after aptoma fix
-			var pixelDensity = parseInt(window.devicePixelRatio || 1, 10) >= 2? 2 : 1;
-
-			this.page = page = new Alf.layout.Page({
-				pixelRatio: pixelDensity,
-				layer: this.pageLayer,
-				widgets: widgets,
-				assetsBaseUrl: assetsBaseUrl
-			});
-
-			page.on('loadComplete', function () {
-				onDone();
-			});
-
-			page.decompile(deskedPage, function () {
-			   page.render(pageContentEl);
-			});
-
-		},
-
-        /**
-         * Clear the page on screen
-         *
-         * @param {Function} onDone
-         * @return {void}
-         */
-        clearPage: function (pageContentEl) {
-            if (this.page) {
-                this.page.tearDown();
-                this.page = null;
+                this.frameIndex = (this.frameIndex + 1) % this.eventFrames.length;
+                if (app.isEmbeddedInApp) {
+                    this.eventFrames[this.frameIndex].src = 'event://' + escape(eventInfo);
+                } else {
+                    app.logToConsole('Event: ' + eventInfo);
+                }
             }
-            pageContentEl.html("");
-        },
+        });
 
-        exitFullscreen: function () {
-            app.fullscreenLayer.exitFullscreen();
+        this.bridge.initialize();
+    },
+
+    /**
+     * Initialize layers
+     *
+     * This is to enable fullscreen support
+     * The article/pages and fullscreen elements are rendered in different "layers"
+     *
+     * @return {void}
+     */
+    initLayers: function () {
+        this.layerManager = new Alf.layer.Manager();
+
+        this.pageLayer = new Alf.layer.Page({
+            el: '#alf-layer-content',
+            widgets: widgets,
+            manager: this.layerManager
+        });
+
+        this.fullscreenLayer = new Alf.layer.Fullscreen({
+            el: '#alf-layer-fullscreen',
+            manager: this.layerManager
+        });
+
+        this.pageLayer.render();
+        this.fullscreenLayer.render();
+    },
+
+
+    /**
+     * Render the page on screen
+     *
+     * Takes the compiled content and uses Alf.layout.Page to do rendering
+     *
+     * @param {HTMLElement} el the element to put the page inside
+     * @param {Object} deskedPage
+     * @param {String} contextHash used for race conditions
+     * @param {String} assetsBaseUrl
+     * @param {Function} onDone
+     * @return {void}
+     */
+    renderPage: function (pageContentEl, deskedPage, assetsBaseUrl, onDone) {
+        if (this.page) {
+            this.page.tearDown();
+            this.page = null;
         }
 
-    };
+        var page;
+        //TODO: remove after aptoma fix
+        var pixelDensity = parseInt(window.devicePixelRatio || 1, 10) >= 2 ? 2 : 1;
 
-	app.initialize();
-	window.app = app;
-	window.onerror = function(message, url, linenumber) {
-		var error = url + ':' + linenumber + ' - ' + message;
-		app.logToConsole(error);
-		app.bridge.trigger('error', {
-			"reason": error
-		});
-	};
+        this.page = page = new Alf.layout.Page({
+            pixelRatio: pixelDensity,
+            layer: this.pageLayer,
+            widgets: widgets,
+            assetsBaseUrl: assetsBaseUrl
+        });
 
+        page.on('loadComplete', function () {
+            onDone();
+        });
 
-	Alf.hub.on('fullscreenWillAppear', function () {
-		app.bridge.trigger('displayState', {"event":'fullscreenWillAppear'});
-	}, this);
+        page.decompile(deskedPage, function () {
+            page.render(pageContentEl);
+        });
 
-	Alf.hub.on('fullscreenWillDisappear', function () {
-		app.bridge.trigger('displayState', {"event":'fullscreenWillDisappear'});
-	}, this);
+    },
 
-	Alf.hub.on('fullscreenDidAppear', function() {
-		app.bridge.trigger('displayState', {"event":'fullscreenDidAppear'});
-	});
+    /**
+     * Clear the page on screen
+     *
+     * @param {Function} onDone
+     * @return {void}
+     */
+    clearPage: function (pageContentEl) {
+        if (this.page) {
+            this.page.tearDown();
+            this.page = null;
+        }
+        pageContentEl.html("");
+    },
 
-	Alf.hub.on('fullscreenDidDisappear', function() {
-		app.bridge.trigger('displayState', {"event":'fullscreenDidDisappear'});
-	});
+    exitFullscreen: function () {
+        app.fullscreenLayer.exitFullscreen();
+    }
+};
 
-	app.event.on('renderPage', function(args) {
-		setTimeout(function(){ // delay for allowing main thread to continue 
-			var pageContentEl = $('#alf-layer-content');
+app.initialize();
 
-			window.scrollTo(0, 0);
-			app.renderPage(pageContentEl, args.json, args.assetsBaseUrl, function() {
-				if('onReadyForDisplay' in args && !!args.onReadyForDisplay) {
-					app.bridge.trigger(args.onReadyForDisplay, {
-						"contextHash": args.contextHash
-					});
-				}
-			});
-			if('onRenderCompleted' in args && !!args.onRenderCompleted) {
-				app.bridge.trigger(args.onRenderCompleted, {
-					"contextHash": args.contextHash
-				});
-			}
-		}, 10);
-	});
-
-    app.event.on('clearPage', function(args) {
-        var pageContentEl = $('#alf-layer-content');
-        app.clearPage(pageContentEl);
+window.onerror = function (message, url, linenumber) {
+    var error = url + ':' + linenumber + ' - ' + message;
+    app.logToConsole(error);
+    app.bridge.trigger('error', {
+        "reason": error
     });
+};
 
-	app.event.on('clientInfo', function (info) {
-		app.logToAll('Got clientInfo:');
-	});
+Alf.hub.on('fullscreenWillAppear', function () {
+    app.bridge.trigger('displayState', {
+        "event": 'fullscreenWillAppear'
+    });
+}, this);
 
-	app.event.on('networkReachability', function (state) {
-		app.logToAll('Got networkReachability:');
-	});
+Alf.hub.on('fullscreenWillDisappear', function () {
+    app.bridge.trigger('displayState', {
+        "event": 'fullscreenWillDisappear'
+    });
+}, this);
 
-	app.event.on('applicationState', function(state) {
-		app.logToAll('Got applicationState: ' + state);
-	});
-
-	$(document).ready(function () {
-		app.bridge.trigger('integrationLoaded', {});
-	});
-
-	return app;
-
+Alf.hub.on('fullscreenDidAppear', function () {
+    app.bridge.trigger('displayState', {
+        "event": 'fullscreenDidAppear'
+    });
 });
+
+Alf.hub.on('fullscreenDidDisappear', function () {
+    app.bridge.trigger('displayState', {
+        "event": 'fullscreenDidDisappear'
+    });
+});
+
+app.event.on('renderPage', function (args) {
+    setTimeout(function () { // delay for allowing main thread to continue
+        var pageContentEl = $('#alf-layer-content');
+
+        window.scrollTo(0, 0);
+        app.renderPage(pageContentEl, args.json, args.assetsBaseUrl, function () {
+            if ('onReadyForDisplay' in args && !!args.onReadyForDisplay) {
+                app.bridge.trigger(args.onReadyForDisplay, {
+                    "contextHash": args.contextHash
+                });
+            }
+        });
+        if ('onRenderCompleted' in args && !!args.onRenderCompleted) {
+            app.bridge.trigger(args.onRenderCompleted, {
+                "contextHash": args.contextHash
+            });
+        }
+    }, 10);
+});
+
+app.event.on('clearPage', function (args) {
+    var pageContentEl = $('#alf-layer-content');
+    app.clearPage(pageContentEl);
+});
+
+app.event.on('clientInfo', function (info) {
+    app.logToAll('Got clientInfo:');
+});
+
+app.event.on('networkReachability', function (state) {
+    app.logToAll('Got networkReachability:');
+});
+
+app.event.on('applicationState', function (state) {
+    app.logToAll('Got applicationState: ' + state);
+});
+
+$(document).ready(function () {
+    app.bridge.trigger('integrationLoaded', {});
+});
+
+module.exports = app;

--- a/js/widget/banner.js
+++ b/js/widget/banner.js
@@ -1,179 +1,84 @@
-define('js/widgets/banner', ['alf'], function(Alf){
-    "use strict";
-    var $ = Alf.dom;
+"use strict";
 
-    var trafficScript = 'http://www.aftenposten.no/resources/js/mno/utils/trafficfund_fif.js';
+var Alf = require('alf');
+var $ = Alf.dom;
+var trafficScript = 'http://www.aftenposten.no/resources/js/mno/utils/trafficfund_fif.js';
 
-    return {
-        selector: '.banner-fullwidth',
+module.exports = {
+    selector: '.banner-fullwidth',
 
-        run: function(done){
-            var container = this.container;
-            var sectionName = container.$el.find(":first-child").attr("data-section");
+    run: function (done) {
+        var container = this.container;
+        var sectionName = container.$el.find(":first-child").attr("data-section");
 
-            container.$el.empty();
+        container.$el.empty();
 
-            if(sectionName === 'dødsfall') {
-                done();
-                return;
-            }
-
-            var banners = {
-                "nyheter": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509585|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Nyheter:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509596|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Nyheter:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ],
-                "økonomi": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509586|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Okonomi:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509598|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Okonomi:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ],
-                "osloby": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509587|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Osloby:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509588|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Osloby:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ],
-                "reise": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509589|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Reise:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509592|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Reise:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ],
-                "bil": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509591|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bil:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509593|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bil:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ],
-                "sport": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509594|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Sport:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509597|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Sport:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ],
-                "kultur": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509595|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Kultur:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509601|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Kultur:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ],
-                "bolig": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5616303|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bolig:TopBoard;loc=100;target=_blank;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5616302|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bolig:SuperBoard1;loc=100;target=_blank;grp=[group];misc='
-                ],
-                "other": [
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509590|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Other:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
-                    'http://adserver.adtech.de/addyn|3.0|1582.1|5509600|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Other:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
-                ]
-            }
-
-            var sectionBanners = banners[sectionName] || banners['other'];
-
-            var randomBanner = Math.floor(Math.random()*sectionBanners.length);
-            var url = sectionBanners[randomBanner] + new Date().getTime();
-
-            var iframe = document.createElement('iframe');
-            iframe.className = 'ad-iframe';
-            iframe.seamless = 'seamless';
-            iframe.scrolling='no';
-            var html = '<body marginwidth="0" marginheight="0" leftmargin="0" topmargin="0" rightmargin="0">'+
-                '<scr'+'ipt  src="' +
-                    url +
-                '"></scri'+'pt>'+
-                '<scr'+'ipt >;window.trafficfund_domain="aftenposten.no";</scri'+'pt>'+
-                '<scr'+'ipt  src="' +
-                    trafficScript +
-                '"></scri'+'pt>'+
-                '</body>';
-
-            iframe.src = 'data:text/html;charset=utf-8,' + encodeURI(html);
-            container.$el.append(iframe);
-
+        if(sectionName === 'dødsfall') {
             done();
+            return;
         }
-    };
-});
 
-define('js/widgets/phonebanner', ['alf'], function (Alf) {
-    "use strict";
-    var $ = Alf.dom;
-    var trafficScript = 'http://www.aftenposten.no/resources/js/mno/utils/trafficfund_fif.js';
+        var banners = {
+            "nyheter": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509585|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Nyheter:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509596|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Nyheter:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ],
+            "økonomi": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509586|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Okonomi:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509598|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Okonomi:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ],
+            "osloby": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509587|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Osloby:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509588|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Osloby:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ],
+            "reise": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509589|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Reise:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509592|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Reise:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ],
+            "bil": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509591|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bil:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509593|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bil:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ],
+            "sport": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509594|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Sport:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509597|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Sport:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ],
+            "kultur": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509595|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Kultur:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509601|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Kultur:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ],
+            "bolig": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5616303|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bolig:TopBoard;loc=100;target=_blank;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5616302|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Bolig:SuperBoard1;loc=100;target=_blank;grp=[group];misc='
+            ],
+            "other": [
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509590|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Other:TopBoard;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc=',
+                'http://adserver.adtech.de/addyn|3.0|1582.1|5509600|0|1744|ADTECH;cookie=info;alias=SB_AftenpostenPluss_Tablet:Other:SuperBoard1;loc=100;target=_blank;key=key1+key2+key3+key4;grp=[group];misc='
+            ]
+        }
 
-    return {
-        selector: '.phone-banner',
+        var sectionBanners = banners[sectionName] || banners['other'];
 
-        run: function (done) {
-            var container = this.container;
-            var sectionName = container.$el.find(":first-child").attr("data-section");
+        var randomBanner = Math.floor(Math.random()*sectionBanners.length);
+        var url = sectionBanners[randomBanner] + new Date().getTime();
 
-            container.$el.empty();
-            
-            if(sectionName === 'dødsfall') {
-                done();
-                return;
-            }
-
-            var banners = {
-                "nyheter": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Nyheter:TopBoard;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Nyheter:NetBoard1;misc='
-                ],
-                "kultur": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Kultur:NetBoard1;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Kultur:TopBoard;misc='
-                ],
-                "økonomi": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Okonomi:NetBoard1;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Okonomi:TopBoard;misc='
-                ],
-                "osloby": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Osloby:TopBoard;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Osloby:NetBoard1;misc='
-                ],
-                "bil": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bil:TopBoard;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bil:NetBoard1;misc='
-                ],
-                "reise": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Reise:NetBoard1;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Reise:TopBoard;misc='
-                ],
-                "sport": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Sport:NetBoard1;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Sport:TopBoard;misc='
-                ],
-                "bolig": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bolig:TopBoard;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bolig:NetBoard1;misc='
-                ],
-                "familie": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Familie:TopBoard;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Familie:NetBoard1;misc='
-                ],
-                "jobb": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Jobb:NetBoard1;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Jobb:TopBoard;misc='
-                ],
-                "other": [
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Other:TopBoard;misc=',
-                    'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Other:NetBoard1;misc='
-                ]
-            };
-
-            var sectionArray = banners[sectionName] || banners["other"];
-
-            var randomBanner = Math.floor(Math.random() * sectionArray.length);
-            var url = sectionArray[randomBanner] + new Date().getTime();
-
-            var phoneadwrapper = document.createElement('div');
-            phoneadwrapper.className = 'phone-ad-wrap';
-            var iframe = document.createElement('iframe');
-            iframe.className = 'ad-iframe';
-            iframe.scrolling = 'no';
-            var html = '<head><style>img {max-width : 100%}</style></head><body marginwidth="0" marginheight="0" leftmargin="0" topmargin="0" rightmargin="0">'
-                + '<scr' + 'ipt  src="' +
+        var iframe = document.createElement('iframe');
+        iframe.className = 'ad-iframe';
+        iframe.seamless = 'seamless';
+        iframe.scrolling='no';
+        var html = '<body marginwidth="0" marginheight="0" leftmargin="0" topmargin="0" rightmargin="0">'+
+            '<scr'+'ipt  src="' +
                 url +
-                '"></scri' + 'pt>' +
-                '<scr' + 'ipt >;window.trafficfund_domain="aftenposten.no";</scri' + 'pt>' +
-                '<scr' + 'ipt  src="' +
+            '"></scri'+'pt>'+
+            '<scr'+'ipt >;window.trafficfund_domain="aftenposten.no";</scri'+'pt>'+
+            '<scr'+'ipt  src="' +
                 trafficScript +
-                '"></scri' + 'pt>' +
-                '</body>';
-            iframe.src = 'data:text/html;charset=utf-8,' + encodeURI(html);
-            phoneadwrapper.appendChild(iframe);
-            container.$el.append(phoneadwrapper);
+            '"></scri'+'pt>'+
+            '</body>';
 
-            done();
-        }
-    };
-});
+        iframe.src = 'data:text/html;charset=utf-8,' + encodeURI(html);
+        container.$el.append(iframe);
+
+        done();
+    }
+};

--- a/js/widget/disqus.js
+++ b/js/widget/disqus.js
@@ -1,41 +1,41 @@
-define('js/widgets/disqus', ['alf'], function(Alf){
-    "use strict";
-    var $ = Alf.dom;
+"use strict";
 
-    return {
-        selector: '.lp-widget-disqus',
-        //selector: 'div',
+var Alf = require('alf');
+var $ = Alf.dom;
 
-        run: function(done){
+module.exports = {
+    selector: '.lp-widget-disqus',
+    //selector: 'div',
 
-            var $this = this.$el;
-            var shortname = $this.attr('shortname');
-            var query = $this.attr('data-query');
-            //$this.text('Kommentarer');
+    run: function(done){
 
-            var treshhold = 100;
-            var skip = false;
+        var $this = this.$el;
+        var shortname = $this.attr('shortname');
+        var query = $this.attr('data-query');
+        //$this.text('Kommentarer');
 
-            function openComments(){
-                if(skip) {
-                    console.log('block it');
-                    return;
-                }
+        var treshhold = 100;
+        var skip = false;
 
-                //console.log('Comments for: ' + shortname + ' ' + query);
-                var url = 'http://lisa.aftenposten.no/aftenposten_pluss/stage/integration/disqus.html?shortname='+shortname+'&identifier='+query;
-                window.location.href = url;
-
-                skip = true;
-                setTimeout(function(){
-                    skip = false;
-                }, treshhold);
-
+        function openComments(){
+            if(skip) {
+                console.log('block it');
+                return;
             }
 
-            $this.tap(openComments);
+            //console.log('Comments for: ' + shortname + ' ' + query);
+            var url = 'http://lisa.aftenposten.no/aftenposten_pluss/stage/integration/disqus.html?shortname='+shortname+'&identifier='+query;
+            window.location.href = url;
 
-            done();
+            skip = true;
+            setTimeout(function(){
+                skip = false;
+            }, treshhold);
+
         }
-    };
-});
+
+        $this.tap(openComments);
+
+        done();
+    }
+};

--- a/js/widget/disqus.js
+++ b/js/widget/disqus.js
@@ -7,7 +7,7 @@ module.exports = {
     selector: '.lp-widget-disqus',
     //selector: 'div',
 
-    run: function(done){
+    run: function (done) {
 
         var $this = this.$el;
         var shortname = $this.attr('shortname');
@@ -17,24 +17,24 @@ module.exports = {
         var treshhold = 100;
         var skip = false;
 
-        function openComments(){
-            if(skip) {
+        function openComments() {
+            if (skip) {
                 console.log('block it');
                 return;
             }
 
             //console.log('Comments for: ' + shortname + ' ' + query);
-            var url = 'http://lisa.aftenposten.no/aftenposten_pluss/stage/integration/disqus.html?shortname='+shortname+'&identifier='+query;
+            var url = 'http://lisa.aftenposten.no/aftenposten_pluss/stage/integration/disqus.html?shortname=' + shortname + '&identifier=' + query;
             window.location.href = url;
 
             skip = true;
-            setTimeout(function(){
+            setTimeout(function() {
                 skip = false;
             }, treshhold);
 
         }
 
-        $this.tap(openComments);
+        $this.on('tap', openComments);
 
         done();
     }

--- a/js/widget/phonebanner.js
+++ b/js/widget/phonebanner.js
@@ -1,0 +1,93 @@
+"use strict";
+
+var Alf = require('alf');
+var $ = Alf.dom;
+var trafficScript = 'http://www.aftenposten.no/resources/js/mno/utils/trafficfund_fif.js';
+
+module.exports = {
+    selector: '.phone-banner',
+
+    run: function (done) {
+        var container = this.container;
+        var sectionName = container.$el.find(":first-child").attr("data-section");
+
+        container.$el.empty();
+
+        if(sectionName === 'dødsfall') {
+            done();
+            return;
+        }
+
+        var banners = {
+            "nyheter": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Nyheter:TopBoard;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Nyheter:NetBoard1;misc='
+            ],
+            "kultur": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Kultur:NetBoard1;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Kultur:TopBoard;misc='
+            ],
+            "økonomi": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Okonomi:NetBoard1;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Okonomi:TopBoard;misc='
+            ],
+            "osloby": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Osloby:TopBoard;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Osloby:NetBoard1;misc='
+            ],
+            "bil": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bil:TopBoard;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bil:NetBoard1;misc='
+            ],
+            "reise": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Reise:NetBoard1;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Reise:TopBoard;misc='
+            ],
+            "sport": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Sport:NetBoard1;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Sport:TopBoard;misc='
+            ],
+            "bolig": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bolig:TopBoard;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Bolig:NetBoard1;misc='
+            ],
+            "familie": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Familie:TopBoard;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Familie:NetBoard1;misc='
+            ],
+            "jobb": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Jobb:NetBoard1;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Jobb:TopBoard;misc='
+            ],
+            "other": [
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Other:TopBoard;misc=',
+                'http://a.adtech.de/addyn/3.0/1582.1/0/0/-1/ADTECH;loc=100;grp=%5Bgroup%5D;alias=SB_AftenpostenPluss_Mobile:Other:NetBoard1;misc='
+            ]
+        };
+
+        var sectionArray = banners[sectionName] || banners["other"];
+
+        var randomBanner = Math.floor(Math.random() * sectionArray.length);
+        var url = sectionArray[randomBanner] + new Date().getTime();
+
+        var phoneadwrapper = document.createElement('div');
+        phoneadwrapper.className = 'phone-ad-wrap';
+        var iframe = document.createElement('iframe');
+        iframe.className = 'ad-iframe';
+        iframe.scrolling = 'no';
+        var html = '<head><style>img {max-width : 100%}</style></head><body marginwidth="0" marginheight="0" leftmargin="0" topmargin="0" rightmargin="0">'
+            + '<scr' + 'ipt  src="' +
+            url +
+            '"></scri' + 'pt>' +
+            '<scr' + 'ipt >;window.trafficfund_domain="aftenposten.no";</scri' + 'pt>' +
+            '<scr' + 'ipt  src="' +
+            trafficScript +
+            '"></scri' + 'pt>' +
+            '</body>';
+        iframe.src = 'data:text/html;charset=utf-8,' + encodeURI(html);
+        phoneadwrapper.appendChild(iframe);
+        container.$el.append(phoneadwrapper);
+
+        done();
+    }
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,34 @@
+{
+  "name": "integration-aftenposten-test",
+  "version": "1.0.0",
+  "dependencies": {
+    "alf": {
+      "version": "2.0.0",
+      "from": "alf@>=2.0.0 <3.0.0",
+      "dependencies": {
+        "backbone": {
+          "version": "1.2.2",
+          "from": "backbone@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.2.tgz",
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "from": "underscore@>=1.7.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+            }
+          }
+        },
+        "jquery": {
+          "version": "2.1.4",
+          "from": "jquery@>=2.1.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "integration-aftenposten-test",
+  "version": "1.0.0",
+  "description": "Aftenposten+ integration",
+  "main": "js/main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "browserify js/main.js -o dist/app.js -s app",
+    "dist": "cp ./node_modules/alf/alf.css dist/alf.css"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ivyengine/integration-aftenposten-test.git"
+  },
+  "author": "",
+  "license": "Unlicense",
+  "bugs": {
+    "url": "https://github.com/ivyengine/integration-aftenposten-test/issues"
+  },
+  "homepage": "https://github.com/ivyengine/integration-aftenposten-test#readme",
+  "devDependencies": {
+    "alf": "^2.0.0",
+    "browserify": "^11.0.1"
+  },
+  "browser": {
+    "alf": "alf/alf-deps.js"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   },
   "homepage": "https://github.com/ivyengine/integration-aftenposten-test#readme",
   "devDependencies": {
-    "alf": "^2.0.0",
     "browserify": "^11.0.1"
   },
   "browser": {
     "alf": "alf/alf-deps.js"
+  },
+  "dependencies": {
+    "alf": "^2.0.0"
   }
 }


### PR DESCRIPTION
The only breaking change is that you need to run `npm run build` and `npm run dist` before the content of the repo is usable.

It's not an issue for the new apps which download from S3 since this is now run by the createZip.sh script, but it's currently an issue for apps running it directly from source.

Are the old apps using http://ivyengine.github.io/integration-aftenposten-test/?